### PR TITLE
Fixed typo in constant NON_AUTHORATIVE_INFORMATION

### DIFF
--- a/src/RFC/RFC2616.php
+++ b/src/RFC/RFC2616.php
@@ -151,7 +151,19 @@ interface RFC2616 extends DraftStandard, IETFStream
      *
      * @var int
      */
-    const NON_AUTHORATIVE_INFORMATION = 203;
+    const NON_AUTHORITATIVE_INFORMATION = 203;
+
+    /**
+     * The 203 (Non-Authoritative Information) status code used to be available
+     * via NON_AUTHORATIVE_INFORMATION, which contained a typo. This typo has
+     * since been fixed and this constant has been deprecated in favor of the
+     * properly spelled constant.
+     *
+     * @see Teapot\StatusCode\RFC\RFC2616:NON_AUTHORITATIVE_INFORMATION
+     * @var int
+     * @deprecated
+     */
+    const NON_AUTHORATIVE_INFORMATION = self::NON_AUTHORITATIVE_INFORMATION;
 
     /**
      * The server has fulfilled the request but does not need to return an

--- a/src/RFC/RFC7231.php
+++ b/src/RFC/RFC7231.php
@@ -207,7 +207,19 @@ interface RFC7231 extends ProposedStandard, IETFStream
      * @codingStandardsIgnoreEnd
      * @var int
      */
-    const NON_AUTHORATIVE_INFORMATION = 203;
+    const NON_AUTHORITATIVE_INFORMATION = 203;
+
+    /**
+     * The 203 (Non-Authoritative Information) status code used to be available
+     * via NON_AUTHORATIVE_INFORMATION, which contained a typo. This typo has
+     * since been fixed and this constant has been deprecated in favor of the
+     * properly spelled constant.
+     *
+     * @see Teapot\StatusCode\RFC\RFC7231:NON_AUTHORITATIVE_INFORMATION
+     * @var int
+     * @deprecated
+     */
+    const NON_AUTHORATIVE_INFORMATION = self::NON_AUTHORITATIVE_INFORMATION;
 
     /**
      * The 204 (No Content) status code indicates that the server has

--- a/src/Vendor/Symfony.php
+++ b/src/Vendor/Symfony.php
@@ -68,7 +68,7 @@ interface Symfony
     const HTTP_OK                                                        = RFC7231::OK;
     const HTTP_CREATED                                                   = RFC7231::CREATED;
     const HTTP_ACCEPTED                                                  = RFC7231::ACCEPTED;
-    const HTTP_NON_AUTHORITATIVE_INFORMATION                             = RFC7231::NON_AUTHORATIVE_INFORMATION;
+    const HTTP_NON_AUTHORITATIVE_INFORMATION                             = RFC7231::NON_AUTHORITATIVE_INFORMATION;
     const HTTP_NO_CONTENT                                                = RFC7231::NO_CONTENT;
     const HTTP_RESET_CONTENT                                             = RFC7231::RESET_CONTENT;
     const HTTP_PARTIAL_CONTENT                                           = RFC7233::PARTIAL_CONTENT;


### PR DESCRIPTION
Deprecated the old constant so current installs can keep using it.