### PR TITLE
Fix: Do not configure bin directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "squizlabs/php_codesniffer": "^3.2"
   },
   "config": {
-    "bin-dir": "bin",
     "optimize-autoloader": true,
     "platform": {
       "php": "5.4.45"


### PR DESCRIPTION
This PR

* [x] stops configuring the `bin` directory 