### PR TITLE
Fix: Remove deprecated constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ For a full diff see [`v1.1.2...main`][v1.1.2...main].
 
 - Updated links to RFCs ([#24]), by [@localheinz]
 
+### Removed
+
+- Removed deprecated constants `Teapot\StatusCode\RFC\RFC7231::NON_AUTHORATIVE_INFORMATION` and `Teapot\StatusCode\RFC\RFC2616::NON_AUTHORATIVE_INFORMATION` ([#26]), by [@localheinz]
+
 ## [`v1.1.2`][v1.1.2]
 
 For a full diff see [`v1.1.1...v1.1.2`][v1.1.1...v1.1.2].
@@ -57,5 +61,6 @@ For a full diff see [`1091250...v1.0.0`][1091250...v1.0.0].
 
 [#24]: https://github.com/teapot-php/status-code/pull/24
 [#25]: https://github.com/teapot-php/status-code/pull/25
+[#26]: https://github.com/teapot-php/status-code/pull/26
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RFC/RFC2616.php
+++ b/src/RFC/RFC2616.php
@@ -154,18 +154,6 @@ interface RFC2616 extends DraftStandard, IETFStream
     const NON_AUTHORITATIVE_INFORMATION = 203;
 
     /**
-     * The 203 (Non-Authoritative Information) status code used to be available
-     * via NON_AUTHORATIVE_INFORMATION, which contained a typo. This typo has
-     * since been fixed and this constant has been deprecated in favor of the
-     * properly spelled constant.
-     *
-     * @see Teapot\StatusCode\RFC\RFC2616:NON_AUTHORITATIVE_INFORMATION
-     * @var int
-     * @deprecated
-     */
-    const NON_AUTHORATIVE_INFORMATION = self::NON_AUTHORITATIVE_INFORMATION;
-
-    /**
      * The server has fulfilled the request but does not need to return an
      * entity-body, and might want to return updated metainformation. The
      * response MAY include new or updated metainformation in the form of

--- a/src/RFC/RFC7231.php
+++ b/src/RFC/RFC7231.php
@@ -201,18 +201,6 @@ interface RFC7231 extends ProposedStandard, IETFStream
     const NON_AUTHORITATIVE_INFORMATION = 203;
 
     /**
-     * The 203 (Non-Authoritative Information) status code used to be available
-     * via NON_AUTHORATIVE_INFORMATION, which contained a typo. This typo has
-     * since been fixed and this constant has been deprecated in favor of the
-     * properly spelled constant.
-     *
-     * @see Teapot\StatusCode\RFC\RFC7231:NON_AUTHORITATIVE_INFORMATION
-     * @var int
-     * @deprecated
-     */
-    const NON_AUTHORATIVE_INFORMATION = self::NON_AUTHORITATIVE_INFORMATION;
-
-    /**
      * The 204 (No Content) status code indicates that the server has
      * successfully fulfilled the request and that there is no additional
      * content to send in the response payload body. Metadata in the response


### PR DESCRIPTION
This pull request

- [x] removes constants that have been deprecated because they contained typos